### PR TITLE
Fix bug where computer can see the future

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -29,7 +29,7 @@ const play = function(player){
 	const move = Array(3).fill(0);
 	move[player] = 1;
 	tmpMove.push( move );
-	if( tmpMove.length == 2 ){
+	if( tmpMove.length > 2 ){
 		x.push( tmpMove.shift() );
 		y.push( tmpMove[0] );
 	}


### PR DESCRIPTION
As detailed here the neural network can see the future which makes the network appear more effective than it is.
https://news.ycombinator.com/item?id=20531307
This is verified by running against random input:
`for(i=0; i<100; i++) { play(Math.floor(Math.random()*3)) }`

This change waits an extra step before training to prevent this.

You can view the fix here: http://htmlpreview.github.io/?https://github.com/CamJohnson26/jokenpo/blob/master/index.html
The same random script seems more like what you'd expect now.